### PR TITLE
benchmark matrix generation time

### DIFF
--- a/benchmark/LUSolveBenchmark.hs
+++ b/benchmark/LUSolveBenchmark.hs
@@ -34,10 +34,15 @@ _randomColumnVectors n = Prelude.map (\vs -> M.fromLists (bundle 1 vs )) (bundle
 runLUFactor :: Int -> M.Matrix V.Vector Double
 runLUFactor n = (\(x, _, _) -> x) $ luFactor $ head $ randomSquareMatrices n
 
+genLUFactor ::Int -> M.Matrix V.Vector Double
+genLUFactor n = head $ randomSquareMatrices n
 
 benchmarks :: [Benchmark]
 benchmarks =
-    [ bench "luFactor 100 x 100 matrix"   $ nf runLUFactor 100
+    [ bench "genFactor 100 x 100 matrix"   $ nf genLUFactor 100
+    , bench "luFactor 100 x 100 matrix"   $ nf runLUFactor 100
+    , bench "genFactor 500 x 500 matrix"   $ nf genLUFactor 500
     , bench "luFactor 500 x 500 matrix"   $ nf runLUFactor 500
+    , bench "genFactor 1000 x 1000 matrix" $ nf genLUFactor 1000
     , bench "luFactor 1000 x 1000 matrix" $ nf runLUFactor 1000
     ]


### PR DESCRIPTION
as suggested on haskell-cafe, matrix generation take a significant part
of the time, especially for small matrices (these results were obtained after applying #2):

```
Benchmark luSolve-bench: RUNNING...
benchmarking LUSolve/genFactor 100 x 100 matrix
time                 624.0 μs   (617.6 μs .. 632.4 μs)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 630.4 μs   (621.2 μs .. 653.2 μs)
std dev              46.67 μs   (13.46 μs .. 87.12 μs)
variance introduced by outliers: 62% (severely inflated)

benchmarking LUSolve/luFactor 100 x 100 matrix
time                 1.653 ms   (1.642 ms .. 1.667 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 1.638 ms   (1.629 ms .. 1.647 ms)
std dev              33.47 μs   (27.17 μs .. 42.63 μs)

benchmarking LUSolve/genFactor 500 x 500 matrix
time                 41.45 ms   (40.55 ms .. 42.53 ms)
                     0.998 R²   (0.995 R² .. 0.999 R²)
mean                 41.80 ms   (40.77 ms .. 42.73 ms)
std dev              2.080 ms   (1.468 ms .. 2.840 ms)
variance introduced by outliers: 13% (moderately inflated)

benchmarking LUSolve/luFactor 500 x 500 matrix
time                 149.4 ms   (146.7 ms .. 151.9 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 151.2 ms   (149.6 ms .. 153.1 ms)
std dev              2.665 ms   (1.541 ms .. 4.557 ms)
variance introduced by outliers: 12% (moderately inflated)

benchmarking LUSolve/genFactor 1000 x 1000 matrix
time                 166.9 ms   (148.3 ms .. 183.2 ms)
                     0.984 R²   (0.932 R² .. 0.998 R²)
mean                 164.2 ms   (154.0 ms .. 172.9 ms)
std dev              14.11 ms   (9.906 ms .. 19.95 ms)
variance introduced by outliers: 26% (moderately inflated)

benchmarking LUSolve/luFactor 1000 x 1000 matrix
time                 1.039 s    (1.026 s .. 1.052 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.035 s    (1.029 s .. 1.038 s)
std dev              5.527 ms   (1.211 ms .. 7.288 ms)
variance introduced by outliers: 19% (moderately inflated)

Benchmark luSolve-bench: FINISH
```